### PR TITLE
Add support for MPS without fallback flag

### DIFF
--- a/liveportrait/modules/dense_motion.py
+++ b/liveportrait/modules/dense_motion.py
@@ -46,9 +46,9 @@ class DenseMotionNetwork(nn.Module):
         bs, _, d, h, w = feature.shape
         feature_repeat = feature.unsqueeze(1).unsqueeze(1).repeat(1, self.num_kp+1, 1, 1, 1, 1, 1)      # (bs, num_kp+1, 1, c, d, h, w)
         feature_repeat = feature_repeat.view(bs * (self.num_kp+1), -1, d, h, w)                         # (bs*(num_kp+1), c, d, h, w)
-        sparse_motions = sparse_motions.view((bs * (self.num_kp+1), d, h, w, -1))
+        sparse_motions = sparse_motions.view((bs * (self.num_kp+1), d, h, w, -1))                       # (bs*(num_kp+1), d, h, w, 3)
         try:
-            sparse_deformed = F.grid_sample(feature_repeat, sparse_motions, align_corners=False)        # (bs*(num_kp+1), d, h, w, 3)
+            sparse_deformed = F.grid_sample(feature_repeat, sparse_motions, align_corners=False)        
         except NotImplementedError:
             feature_repeat = feature_repeat.to('cpu')
             sparse_motions = sparse_motions.to('cpu')

--- a/liveportrait/modules/util.py
+++ b/liveportrait/modules/util.py
@@ -161,7 +161,8 @@ class DownBlock3d(nn.Module):
         try:
             out = self.pool(out)
         except NotImplementedError:
-            out = self.pool(out.to('cpu')).to('mps')
+            out_device = out.device # Store input device
+            out = self.pool(out.to('cpu')).to(out_device)
         return out
 
 

--- a/liveportrait/modules/util.py
+++ b/liveportrait/modules/util.py
@@ -158,7 +158,10 @@ class DownBlock3d(nn.Module):
         out = self.conv(x)
         out = self.norm(out)
         out = F.relu(out)
-        out = self.pool(out)
+        try:
+            out = self.pool(out)
+        except NotImplementedError:
+            out = self.pool(out.to('cpu')).to('mps')
         return out
 
 

--- a/liveportrait/modules/warping_network.py
+++ b/liveportrait/modules/warping_network.py
@@ -44,7 +44,10 @@ class WarpingNetwork(nn.Module):
         self.estimate_occlusion_map = estimate_occlusion_map
 
     def deform_input(self, inp, deformation):
-        return F.grid_sample(inp, deformation, align_corners=False)
+        try:
+            return F.grid_sample(inp, deformation, align_corners=False)
+        except NotImplementedError:
+            return F.grid_sample(inp.to('cpu'), deformation.to('cpu'), align_corners=False).to('mps')
 
     def forward(self, feature_3d, kp_driving, kp_source):
         if self.dense_motion_network is not None:

--- a/liveportrait/modules/warping_network.py
+++ b/liveportrait/modules/warping_network.py
@@ -47,7 +47,8 @@ class WarpingNetwork(nn.Module):
         try:
             return F.grid_sample(inp, deformation, align_corners=False)
         except NotImplementedError:
-            return F.grid_sample(inp.to('cpu'), deformation.to('cpu'), align_corners=False).to('mps')
+            out_device = inp.device # Store input device
+            return F.grid_sample(inp.to('cpu'), deformation.to('cpu'), align_corners=False).to(out_device)
 
     def forward(self, feature_3d, kp_driving, kp_source):
         if self.dense_motion_network is not None:


### PR DESCRIPTION
This change manually swaps tensors to cpu for 2 unsupported options on MPS.

Code only trigger on `NotImplementedError` so there should be no side effects for machines that can use the code as it exists normally.