### PR TITLE
Allow for multi-frame masks in LivePortraitComposite

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -436,7 +436,7 @@ class LivePortraitComposite:
                     )
 
                 mask_ori = _transform_img_kornia(
-                    crop_mask,
+                    crop_mask[min(i,len(crop_mask)-1)].unsqueeze(0),
                     crop_info["crop_info_list"][safe_index]["M_c2o"],
                     dsize=(W, H),
                     device=device


### PR DESCRIPTION
Small change to allow for fine-tuning masks with other processes (e.g. image segmentation)